### PR TITLE
bugfix: remove unused modules

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -1,9 +1,6 @@
 var path		= require('path');
 
-var express		= require('express');
 var bodyParser	= require('body-parser');
-var open		= require("open");
-var portfinder	= require('portfinder');
 var Api			= require('athom-api');
 var inquirer	= require('inquirer');
 


### PR DESCRIPTION
Currently node-athom-cli doesn't work because I don't have these modules installed and they are not needed anyway.