### PR TITLE
Fixed support for Node.js 6.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea/

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,10 +1,41 @@
 var fs			= require('fs-extra');
 var path		= require('path-extra');
-var jsop		= require('jsop');
 
 var datadir = path.datadir('com.athom.athom-cli');
 var datafile = path.join( datadir, 'settings.json' );
 
 fs.ensureDirSync(datadir);
 
-global.settings = jsop(datafile);
+if (Object.observe) {
+	var jsop		= require('jsop');
+
+	global.settings = jsop(datafile);
+} else if (typeof Proxy === 'function') {
+	fs.ensureFileSync(datafile);
+
+	var writeDebounce = false;
+	var settingsFile = fs.readFileSync(datafile);
+	global.settings = new Proxy(String(settingsFile) ? JSON.parse(settingsFile) : {}, {
+		// If the settings object is accessed (for read or write) check for changes
+		get: function (target, property) {
+			// Check if there already is a function on process.nextTick
+			if (!writeDebounce) {
+				writeDebounce = true;
+				// On next tick check to write setting changes
+				process.nextTick(function () {
+					writeDebounce = false;
+					const jsonString = JSON.stringify(target, null, 2);
+					// If json is updated, write to file
+					if (jsonString !== settingsFile) {
+						settingsFile = jsonString;
+						fs.outputFileSync(datafile, settingsFile);
+					}
+				});
+			}
+
+			return target[property];
+		}
+	});
+} else {
+	throw new Error('Sorry, you are using an unsupported Node.js version. Please update Node.js and try again.');
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athom-cli",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Command Line Interface for the development of Homey Apps",
   "main": "app.js",
   "repository": {
@@ -15,7 +15,7 @@
     "clone": "^1.0.2",
     "colors": "^1.1.0",
     "commander": "^2.8.1",
-    "fs-extra": "^0.18.4",
+    "fs-extra": "^0.30.0",
     "gitignore-parser": "0.0.2",
     "homey-lib": "^1.0.5",
     "inquirer": "^0.8.3",


### PR DESCRIPTION
Fixed support for Node.js 6.x by checking if Object.observe can be used and if not polyfilling it with ES6 Proxy's

fixes #20 