### PR TITLE
fixed "Cannot read property 'length' of undefined" error

### DIFF
--- a/lib/homey.js
+++ b/lib/homey.js
@@ -83,7 +83,7 @@ module.exports.list = function( log, callback ){
 				address: homey.ipInternal,
 				role: homey.role,
 				token: homey.token,
-				users: homey.users.length,
+				users: (homey.users || []).length,
 			}
 
 			if( log ) {
@@ -158,7 +158,7 @@ module.exports.listLocal = function( log, callback ){
 						address: candidate,
 						role: homey.role,
 						token: homey.token,
-						users: homey.users.length,
+						users: (homey.users || []).length,
 					});
 				} else {
 					homeys.push({


### PR DESCRIPTION
Fixed bug where athom-cli would crash when the "homey" object did not contain a users array.