### PR TITLE
Minor bugfix in RF plugin

### DIFF
--- a/lib/AppPluginRF/index.js
+++ b/lib/AppPluginRF/index.js
@@ -199,11 +199,11 @@ class AppPluginRF extends AppPlugin {
 		};
 
 		await copyDeviceFile(
-			path.join(app.path, 'node_modules', 'homey-rfdriver', 'compose', 'driver', 'driver.js'),
+			path.join(app.path, 'node_modules', 'homey-rfdriver', '.compose', 'driver', 'driver.js'),
 			path.join(driverPath, 'driver.js')
 		);
 		await copyDeviceFile(
-			path.join(app.path, 'node_modules', 'homey-rfdriver', 'compose', 'driver', 'device.js'),
+			path.join(app.path, 'node_modules', 'homey-rfdriver', '.compose', 'driver', 'device.js'),
 			path.join(driverPath, 'device.js')
 		);
 	}


### PR DESCRIPTION
Fixed old reference to 'compose' folder to now point at the '.compose' folder in the RFDriver node module