### PR TITLE
Add settings templates

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -131,11 +131,11 @@ class AppPluginCompose extends AppPlugin {
 						if (!settingsTemplates.hasOwnProperty(templateId)) {
 							throw new Error(`Invalid driver setting template for driver ${driverId}: ${templateId}`);
 						}
-						settingTemplate = Object.assign({}, settingsTemplates[templateId]);
+						settingTemplate = Object.assign(settingTemplate, settingsTemplates[templateId]);
 					}
 
 					Object.assign(settingObj, {
-						id: templateId,
+						id: settingObj.$id || templateId,
 						...settingTemplate,
 						...settingObj,
 					});
@@ -152,8 +152,10 @@ class AppPluginCompose extends AppPlugin {
 			// merge template settings
 			try {
 				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'drivers', 'settings' ) );
-				for (let settingId in driverJson.settings) {
-					extendSetting(settingsTemplates, driverJson.settings[settingId]);
+				if (Array.isArray(driverJson.settings)) {
+					for (let settingId in driverJson.settings) {
+						extendSetting(settingsTemplates, driverJson.settings[settingId]);
+					}
 				}
 			} catch (err) {
 				if( err.code !== 'ENOENT' ) throw new Error(err);

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -13,8 +13,10 @@
 	/.homeycompose/signals/<433|868|ir>/<id>.json
 	/.homeycompose/flow/<triggers|conditions|actions>/<id>.json
 	/.homeycompose/drivers/templates/<template_id>.json
+	/.homeycompose/settings/templates/settings.json
+	/.homeycompose/settings/templates/<setting_id>.json
 	/drivers/<id>/driver.compose.json (extend with "$extends": [ "<template_id>" ])
-	/drivers/<id>/driver.settings.compose.json (array with driver settings)
+	/drivers/<id>/driver.settings.compose.json (array with driver settings, extend with "$extends": "<template_id>"))
 	/drivers/<id>/driver.flow.compose.json (object with flow cards, device arg is added automatically)
 	/.homeycompose/locales/en.json
 	/.homeycompose/locales/en.foo.json
@@ -118,6 +120,30 @@ class AppPluginCompose extends AppPlugin {
 			// merge settings
 			try {
 				driverJson.settings = await this._getJsonFile( path.join(this._appPath, 'drivers', driverId, 'driver.settings.compose.json') );
+
+				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'settings', 'templates' ) );
+
+				// merge template settings
+				for (let settingId in driverJson.settings) {
+					const settingJson = driverJson.settings[settingId];
+					if (settingJson.$extends) {
+						let templateId = driverJson.settings[settingId].$extends;
+
+						let settingTemplate = null;
+						if (settingsTemplates.hasOwnProperty(templateId)) {
+							settingTemplate = settingsTemplates[templateId];
+						} else if (settingsTemplates.hasOwnProperty('settings')) {
+							settingTemplate = settingsTemplates.settings[templateId]
+						}
+
+						delete settingJson.$extends;
+						driverJson.settings[settingId] = {
+							id: templateId,
+							...settingTemplate,
+							...settingJson,
+						};
+					}
+				}
 			} catch( err ) {
 				if( err.code !== 'ENOENT' ) throw new Error(err);
 			}

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -13,8 +13,7 @@
 	/.homeycompose/signals/<433|868|ir>/<id>.json
 	/.homeycompose/flow/<triggers|conditions|actions>/<id>.json
 	/.homeycompose/drivers/templates/<template_id>.json
-	/.homeycompose/settings/templates/settings.json
-	/.homeycompose/settings/templates/<setting_id>.json
+	/.homeycompose/drivers/settings/<setting_id>.json
 	/drivers/<id>/driver.compose.json (extend with "$extends": [ "<template_id>" ])
 	/drivers/<id>/driver.settings.compose.json (array with driver settings, extend with "$extends": "<template_id>"))
 	/drivers/<id>/driver.flow.compose.json (object with flow cards, device arg is added automatically)
@@ -125,11 +124,9 @@ class AppPluginCompose extends AppPlugin {
 				} else if (settingObj.$extends) {
 					let templateId = settingObj.$extends;
 
-					let settingTemplate = null;
+					let settingTemplate = {};
 					if (settingsTemplates.hasOwnProperty(templateId)) {
 						settingTemplate = settingsTemplates[templateId];
-					} else if (settingsTemplates.hasOwnProperty('settings')) {
-						settingTemplate = settingsTemplates.settings[templateId]
 					}
 
 					delete settingObj.$extends;
@@ -144,7 +141,7 @@ class AppPluginCompose extends AppPlugin {
 			// merge settings
 			try {
 				driverJson.settings = await this._getJsonFile( path.join(this._appPath, 'drivers', driverId, 'driver.settings.compose.json') );
-				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'settings', 'templates' ) );
+				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'drivers', 'settings' ) );
 
 				// merge template settings
 				for (let settingId in driverJson.settings) {

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -117,32 +117,39 @@ class AppPluginCompose extends AppPlugin {
 
 			driverJson.id = driverId;
 
+			function extendSetting(settingsTemplates, rootObj, settingObj, index) {
+				if (settingObj.type === 'group') {
+					for (let childSettingId in settingObj.children) {
+						extendSetting(settingsTemplates, settingObj.children, settingObj.children[childSettingId], childSettingId);
+					}
+				} else if (settingObj.$extends) {
+					let templateId = settingObj.$extends;
+
+					let settingTemplate = null;
+					if (settingsTemplates.hasOwnProperty(templateId)) {
+						settingTemplate = settingsTemplates[templateId];
+					} else if (settingsTemplates.hasOwnProperty('settings')) {
+						settingTemplate = settingsTemplates.settings[templateId]
+					}
+
+					delete settingObj.$extends;
+					rootObj[index] = {
+						id: templateId,
+						...settingTemplate,
+						...settingObj,
+					};
+				}
+			}
+
 			// merge settings
 			try {
 				driverJson.settings = await this._getJsonFile( path.join(this._appPath, 'drivers', driverId, 'driver.settings.compose.json') );
-
 				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'settings', 'templates' ) );
 
 				// merge template settings
 				for (let settingId in driverJson.settings) {
 					const settingJson = driverJson.settings[settingId];
-					if (settingJson.$extends) {
-						let templateId = driverJson.settings[settingId].$extends;
-
-						let settingTemplate = null;
-						if (settingsTemplates.hasOwnProperty(templateId)) {
-							settingTemplate = settingsTemplates[templateId];
-						} else if (settingsTemplates.hasOwnProperty('settings')) {
-							settingTemplate = settingsTemplates.settings[templateId]
-						}
-
-						delete settingJson.$extends;
-						driverJson.settings[settingId] = {
-							id: templateId,
-							...settingTemplate,
-							...settingJson,
-						};
-					}
+					extendSetting(settingsTemplates, driverJson.settings, settingJson, settingId);
 				}
 			} catch( err ) {
 				if( err.code !== 'ENOENT' ) throw new Error(err);

--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -116,39 +116,46 @@ class AppPluginCompose extends AppPlugin {
 
 			driverJson.id = driverId;
 
-			function extendSetting(settingsTemplates, rootObj, settingObj, index) {
+			function extendSetting(settingsTemplates, settingObj) {
 				if (settingObj.type === 'group') {
 					for (let childSettingId in settingObj.children) {
-						extendSetting(settingsTemplates, settingObj.children, settingObj.children[childSettingId], childSettingId);
+						extendSetting(settingsTemplates, settingObj.children[childSettingId]);
 					}
 				} else if (settingObj.$extends) {
-					let templateId = settingObj.$extends;
+					let templateIds = [].concat(settingObj.$extends);
 
 					let settingTemplate = {};
-					if (settingsTemplates.hasOwnProperty(templateId)) {
-						settingTemplate = settingsTemplates[templateId];
+					let templateId;
+					for (let i in templateIds) {
+						templateId = templateIds[i];
+						if (!settingsTemplates.hasOwnProperty(templateId)) {
+							throw new Error(`Invalid driver setting template for driver ${driverId}: ${templateId}`);
+						}
+						settingTemplate = Object.assign({}, settingsTemplates[templateId]);
 					}
 
-					delete settingObj.$extends;
-					rootObj[index] = {
+					Object.assign(settingObj, {
 						id: templateId,
 						...settingTemplate,
 						...settingObj,
-					};
+					});
 				}
 			}
 
 			// merge settings
 			try {
 				driverJson.settings = await this._getJsonFile( path.join(this._appPath, 'drivers', driverId, 'driver.settings.compose.json') );
-				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'drivers', 'settings' ) );
-
-				// merge template settings
-				for (let settingId in driverJson.settings) {
-					const settingJson = driverJson.settings[settingId];
-					extendSetting(settingsTemplates, driverJson.settings, settingJson, settingId);
-				}
 			} catch( err ) {
+				if( err.code !== 'ENOENT' ) throw new Error(err);
+			}
+
+			// merge template settings
+			try {
+				let settingsTemplates = await this._getJsonFiles( path.join( this._appPathCompose, 'drivers', 'settings' ) );
+				for (let settingId in driverJson.settings) {
+					extendSetting(settingsTemplates, driverJson.settings[settingId]);
+				}
+			} catch (err) {
 				if( err.code !== 'ENOENT' ) throw new Error(err);
 			}
 


### PR DESCRIPTION
Driver settings can now be templated.

`driver_id/driver.settings.compose.json`:
```
[
  {
    "$extends": "inclusionMode"
  },
]
```

`.homeycompose/settings/templates/includsionMode.json`:
```
{
    "type": "checkbox",
    "label": {
      "en": "Secure inclusion",
      "nl": "Beveiligde modus"
    },
    "zwave": {
      "index": 250,
      "size": 1
    },
    "value": false
  }
```

Setting id gets added automatically based on .json file name.