### PR TITLE
Add drivers flow extending functionality (similar to drivers settings)

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -14,6 +14,7 @@
 	/.homeycompose/flow/<triggers|conditions|actions>/<id>.json
 	/.homeycompose/drivers/templates/<template_id>.json
 	/.homeycompose/drivers/settings/<setting_id>.json
+	/.homeycompose/drivers/flow/<triggers|conditions|actions>/<flow_id>.json (flow card object, id and device arg is added automatically)
 	/drivers/<id>/driver.compose.json (extend with "$extends": [ "<template_id>" ])
 	/drivers/<id>/driver.settings.compose.json (array with driver settings, extend with "$extends": "<template_id>"))
 	/drivers/<id>/driver.flow.compose.json (object with flow cards, device arg is added automatically)
@@ -244,6 +245,18 @@ class AppPluginCompose extends AppPlugin {
 
 			driverJson = replaceSpecialPropertiesRecursive(driverJson);
 
+			// get drivers flow templates
+			let flowTemplates = {};
+			try {
+				for (let i = 0; i < FLOW_TYPES.length; i++) {
+					let type = FLOW_TYPES[i];
+					let typePath = path.join(this._appPathCompose, 'drivers', 'flow', type);
+					flowTemplates[type] = await this._getJsonFiles(typePath);
+				}
+			} catch (err) {
+				if( err.code !== 'ENOENT' ) throw new Error(err);
+			}
+
 			if(typeof driverJson.$flow === 'object' && !Array.isArray(driverJson.$flow)){
 				for( let i = 0; i < FLOW_TYPES.length; i++ ) {
 					let type = FLOW_TYPES[i];
@@ -252,6 +265,22 @@ class AppPluginCompose extends AppPlugin {
 
 					for( let i = 0; i < cards.length; i++ ) {
 						let card = cards[i];
+
+						// extend card if possible
+						if (card.$extends) {
+							let templateCards = flowTemplates[type];
+
+							// check if template is available, else throw error
+							if (!templateCards || !templateCards.hasOwnProperty(card.$extends)) {
+								throw new Error(`Invalid driver flow template for driver ${driverId}: ${card.$extends}`);
+							}
+
+							// assign template to original flow object
+							Object.assign(card, {
+								id: card.$id || card.$extends,
+								...templateCards[card.$extends]
+							});
+						}
 
 						card.args = card.args || [];
 						card.args.unshift({


### PR DESCRIPTION
Like `.homeycompose/drivers/settings` you can now create flow card templates in `.homeycompose/drivers/flows/<type>/flow_id.json`.

Example:
`driver.flow.compose.json`:
```
{
  "triggers": [
    {
      "$extends": "inputTwoTurnedOn"
    }
  ]
```

`.homeycompose/drivers/flow/triggers/inputTwoTurnedOn.json`:
```
{
  "title": {
    "en": "Input 2 turned on",
    "nl": "Ingang 2 is ingeschakeld"
  },
  "hint": {
    "en": "This Flow Trigger is only active if input 2 is enabled on the device, please see the device settings for more information.",
    "nl": "Deze Flow Trigger werkt alleen wanneer ingang 2 is geactiveerd op het apparaat, zie de apparaatinstellingen voor meer informatie."
  }
}
```