### PR TITLE
Extend flow card args, prevents duplicate `type: device` args

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -278,16 +278,28 @@ class AppPluginCompose extends AppPlugin {
 							// assign template to original flow object
 							Object.assign(card, {
 								id: card.$id || card.$extends,
-								...templateCards[card.$extends]
+								...templateCards[card.$extends],
 							});
+							card.args = card.args || [];
+							if (Array.isArray(card.$args)) {
+								card.args = card.args.concat(card.$args);
+							}
 						}
 
-						card.args = card.args || [];
-						card.args.unshift({
-							type: 'device',
-							name: card.$deviceName || 'device',
-							filter: `driver_id=${driverId}`
-						})
+						let hasDeviceArg = false;
+						for (let i = 0; i < card.args.length; i++) {
+							if (card.args[i].type === 'device'){
+								hasDeviceArg = true;
+								break;
+							}
+						}
+						if (!hasDeviceArg) {
+							card.args.unshift({
+								type: 'device',
+								name: card.$deviceName || 'device',
+								filter: `driver_id=${driverId}`
+							});
+						}
 
 						await this._addFlowCard({
 							type,


### PR DESCRIPTION
In the first place this PR prevents duplicate args of type `device`, second, it enables extending the `args` array (using `$args` which will be concatted).