### PR TITLE
Add zwaveParameterIndex special property

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -220,8 +220,15 @@ class AppPluginCompose extends AppPlugin {
 			}
 
 			// replace properties
+			let zwaveParameterIndex = null;
 			function replaceSpecialPropertiesRecursive( obj ) {
 				if( typeof obj !== 'object' ) return obj;
+
+				// store last found zwave parameter index
+				if ( obj.hasOwnProperty('zwave') && obj.zwave.hasOwnProperty('index') ) {
+					zwaveParameterIndex = obj.zwave.index;
+				}
+
 				for( let key in obj ) {
 					if( typeof obj[key] === 'object' ) {
 						obj[key] = replaceSpecialPropertiesRecursive(obj[key]);
@@ -238,12 +245,14 @@ class AppPluginCompose extends AppPlugin {
 						}
 						obj[key] = obj[key].replace(/{{driverPath}}/g, `/drivers/${driverId}`);
 						obj[key] = obj[key].replace(/{{driverAssetsPath}}/g, `/drivers/${driverId}/assets`);
+
+						if (zwaveParameterIndex) {
+							obj[key] = obj[key].replace(/{{zwaveParameterIndex}}/g, zwaveParameterIndex);
+						}
 					}
 				}
 				return obj;
 			}
-
-			driverJson = replaceSpecialPropertiesRecursive(driverJson);
 
 			// get drivers flow templates
 			let flowTemplates = {};
@@ -296,6 +305,8 @@ class AppPluginCompose extends AppPlugin {
 					}
 				}
 			}
+
+			driverJson = replaceSpecialPropertiesRecursive(driverJson);
 
 			// add driver to app.json
 			this._appJson.drivers = this._appJson.drivers || [];


### PR DESCRIPTION
This is useful for writing Z-Wave settings hints (where referring to the parameter index is preferred so that users know which parameter they are changing and can cross check with their manuals).

Also moved `replaceSpecialPropertiesRecursive()` to the bottom so that flow templates are also replaced.