### PR TITLE
Accept Array for flow card extends

### DIFF
--- a/lib/AppPluginCompose/index.js
+++ b/lib/AppPluginCompose/index.js
@@ -268,17 +268,23 @@ class AppPluginCompose extends AppPlugin {
 
 						// extend card if possible
 						if (card.$extends) {
+							let templateIds = [].concat(card.$extends);
 							let templateCards = flowTemplates[type];
 
-							// check if template is available, else throw error
-							if (!templateCards || !templateCards.hasOwnProperty(card.$extends)) {
-								throw new Error(`Invalid driver flow template for driver ${driverId}: ${card.$extends}`);
+							let flowTemplate = {};
+							let templateId;
+							for (let i in templateIds) {
+								templateId = templateIds[i];
+								if (!templateCards.hasOwnProperty(templateId)) {
+									throw new Error(`Invalid driver flow template for driver ${driverId}: ${templateId}`);
+								}
+								flowTemplate = Object.assign(flowTemplate, templateCards[templateId]);
 							}
 
 							// assign template to original flow object
 							Object.assign(card, {
-								id: card.$id || card.$extends,
-								...templateCards[card.$extends]
+								id: card.$id || templateId,
+								...flowTemplate,
 							});
 						}
 


### PR DESCRIPTION
To be consistent with extending device settings, flow cards can now also use an Array as value for `$extends`.